### PR TITLE
make the templates self-describing

### DIFF
--- a/design/meta/process/design-template-1.md
+++ b/design/meta/process/design-template-1.md
@@ -1,36 +1,45 @@
-A Relational Model of Data
+Feature Name
 ==========================
-
-Motivation
-----------
-
-Future users of large data banks must be protected from having to know how the data is organized in the machine.
 
 Summary
 -------
 
-A model based on n-ary relations, a normal form for data base relations, and the concept of a universal data sublanguage are introduced.
+Brief (e.g. one paragraph) explanation of the feature.
+
+Motivation
+----------
+
+Why are we doing this?
+What use cases does it support?
+What is the expected outcome?
 
 Design
 ------
 
-The design consists of component 1, component 2, and component 3, which interact in such-and-such manner.
+Explain the proposal as if it was already included in the
+language and you were teaching it to another programmer.
+That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how programmers should *think* about the feature.
+
+Introduce the components and describe how they might
+interact.
 
 ### Component 1
 
-Component 1 needs to accomplish a certain goal.
+Introduce the goals of the component before explaining
+the different options.
 
 #### Option A
 
-One way to do it is Option A which entails doing it a certain way. This achieves the goal but suffers from problem P.
+Describe the option and how it achieves the goals for this
+component.
 
 #### Option B
 
-Another way to do it is Option B which entails doing it a different way. This achieves the goal but entails a tradeoff of F for G.
-
-#### Recommendation
-
-Option B is a tradeoff worth making, since it also has benefits K and L. It may also be possible to leverage a certain aspect of A to mitigate the loss of P that option B entails.
+...
 
 ### Component 2
 
@@ -40,19 +49,29 @@ Option B is a tradeoff worth making, since it also has benefits K and L. It may 
 
 ...
 
-Prior art
+Evaluation and Tradeoffs
+--------------
+
+Explain the tradeoffs between the various combinations of
+options.
+
+Prior art and References
 ---------
 
-Bachman, C. W. "Software for Random Access Processing"
-McGee, W. C. "Generalized File Processing"
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+- Does this feature exist in other programming languages and what experience have their community had?
+- Papers: Are there published papers, books, great blog posts, etc that discuss this? Be _specific_!
+
+Drawbacks and Unresolved questions
+----------------------------------
+
+- Why should we *not* do this? Could we do something else instead?
+- What parts of the design do you expect to resolve through the PR and discussion process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this feature that could be addressed in the future independently of the solution that comes out of this design?
 
 Contributors
 ------------
 
-* Alyssa P. Hacker
-* Eva Lu Ator
-
-References
-----------
-
-Codd, E.F (1970). "A Relational Model of Data for Large Shared Data Banks"
+List people who've contributed to this design.

--- a/design/meta/process/design-template-2.md
+++ b/design/meta/process/design-template-2.md
@@ -1,65 +1,77 @@
-A Relational Model of Data
+Feature Name
 ==========================
-
-Motivation
-----------
-
-Future users of large data banks must be protected from having to know how the data is organized in the machine.
 
 Summary
 -------
 
-A model based on n-ary relations, a normal form for data base relations, and the concept of a universal data sublanguage are introduced.
+Brief (e.g. one paragraph) explanation of the feature.
+
+Motivation
+----------
+
+Why are we doing this?
+What use cases does it support?
+What is the expected outcome?
 
 Design Options
 --------------
 
 ### Option A
 
-In this approach, the design consists of component 1, component 2, and component 3, which interact in such-and-such manner.
+Explain the proposal as if it was already included in the
+language and you were teaching it to another programmer.
+That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how programmers should *think* about the feature.
 
 #### Component 1
 
-Component 1 works in the following way.
+Introduce each component's behavior on its own if possible.
 
 #### Component 2
 
-Component 2 fits into the picture in this way.
+When a component interacts with other components, show
+examples with simple cases of the other components first,
+before combining them in more complex ways.
 
-#### Evaluation
-
-This option entails the following tradeoffs.
+...
 
 ### Option B
 
-In this approach, the design consists of component 1 and component 2, which interact in such-and-such manner.
+Explain the components that differ from other options.
+
+#### Component 2
+
+When this component interacts with others, include more
+examples showing its behavior with other components at the
+end.
 
 ...
 
-### Option C
-
-This is just like Option B, except that Component 2 is modified in the following way.
-
-...
-
-Recommendation
+Evaluation and Tradeoffs
 --------------
 
-Option B is a tradeoff worth making, since it also has benefits K and L. It may also be possible to leverage a certain aspect of Option A to mitigate the loss of P that option B entails.
+Explain the tradeoffs between the various options.
 
-Prior art
+Prior art and References
 ---------
 
-Bachman, C. W. "Software for Random Access Processing"
-McGee, W. C. "Generalized File Processing"
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+- Does this feature exist in other programming languages and what experience have their community had?
+- Papers: Are there published papers, books, great blog posts, etc that discuss this? Be _specific_!
+
+Drawbacks and Unresolved questions
+----------------------------------
+
+- Why should we *not* do this? Could we do something else instead?
+- What parts of the design do you expect to resolve through the PR and discussion process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this feature that could be addressed in the future independently of the solution that comes out of this design?
 
 Contributors
 ------------
 
-* Alyssa P. Hacker
-* Eva Lu Ator
-
-References
-----------
-
-Codd, E.F (1970). "A Relational Model of Data for Large Shared Data Banks"
+List people who've contributed to this design.


### PR DESCRIPTION
Makes both of the templates self-describing, to make templates resemble each other more while also keeping the advantages that were originally in the 2nd template.

This also puts summary be put before the motivation, because I expect the summary to be short, while the motivation might be longer in some cases. Also in some cases the motivation might make more sense after reading a short summary.

The different "Evaluation" sections for the components/options have been combined into one "Evaluation and Tradeoffs" section.

The Prior Art and References sections are also combined, and so on.

Previews:
- template 1: https://github.com/AlexKnauth/rhombus-prototype/blob/process-docs-2/design/meta/process/design-template-1.md
- template 2: https://github.com/AlexKnauth/rhombus-prototype/blob/process-docs-2/design/meta/process/design-template-2.md